### PR TITLE
If using Rails remove the `Rails.root` path from the module name

### DIFF
--- a/lib/sprockets/traceur.rb
+++ b/lib/sprockets/traceur.rb
@@ -19,7 +19,12 @@ module Sprockets
 
       def evaluate(scope, locals, &block)
         name = module_name(scope)
-        ::Traceur.compile(data, module_name: name, filename: file)
+
+        if ::Rails.present?
+          filename = file.gsub(/^#{::Rails.root}/, '')
+        end
+
+        ::Traceur.compile(data, module_name: name, filename: filename)
       end
 
       private


### PR DESCRIPTION
- This is to allow consistent builds across multiple server machines

I'd imagine you'll probably want this to be optional, but since there aren't currently any configurable settings in this gem i didn't want to dictate an approach to its configuration. Let me know if you'd like me to implement something as part of this PR.
